### PR TITLE
App/Service: Implement an empty foreground service

### DIFF
--- a/ml_inference_offloading/src/main/AndroidManifest.xml
+++ b/ml_inference_offloading/src/main/AndroidManifest.xml
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Nnstreamerandroid">
+
+        <service
+            android:name=".MainService"
+            android:enabled="true"
+            android:exported="true"
+            android:foregroundServiceType="specialUse" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -14,6 +25,7 @@
             android:theme="@style/Theme.Nnstreamerandroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import ai.nnstreamer.ml.inference.offloading.ui.theme.NnstreamerandroidTheme
+import android.content.Intent
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,5 +25,7 @@ class MainActivity : ComponentActivity() {
                 ) { }
             }
         }
+
+        startForegroundService(Intent(this, MainService::class.java))
     }
 }

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
@@ -1,0 +1,105 @@
+package ai.nnstreamer.ml.inference.offloading
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Process
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+
+class MainService : Service() {
+    private inner class MainHandler(looper: Looper) : Handler(looper) {
+        override fun handleMessage(msg: Message) {
+            super.handleMessage(msg)
+            try {
+                // Sleep for 10 secs
+                Thread.sleep(10000)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            stopSelf(msg.arg1)
+        }
+    }
+
+    private val TAG = "MainService"
+    private lateinit var serviceHandler : MainHandler
+    private lateinit var serviceLooper : Looper
+    private lateinit var handlerThread: HandlerThread
+
+    private fun startForeground() {
+        // Get NotificationManager
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+        // todo: Maintain a separate (data) class if needed
+        // Declare a new Notification channel
+        val chId = "mainService_ch0"
+        val chName = "ch0"
+        val chImportance = NotificationManager.IMPORTANCE_HIGH
+        val notificationChannel : NotificationChannel = NotificationChannel(chId, chName, chImportance).apply {
+            val chDesc = "This is a notification channel to run this service in the foreground."
+
+            description = chDesc
+        }
+
+        // Create the notification channel declared above
+        notificationManager.createNotificationChannel(notificationChannel)
+        val notification = NotificationCompat.Builder(this, chId).apply {
+            setSmallIcon(android.R.drawable.ic_notification_overlay)
+            setWhen(System.currentTimeMillis())
+            setContentTitle("Main Service Notification")
+            setContentText("The foreground service has been started!")
+        }.build()
+
+
+        // Check the FOREGROUND_SERVICE_SPECIAL_USE permission
+        val spUsePermission = ContextCompat.checkSelfPermission(this, Manifest.permission.FOREGROUND_SERVICE_SPECIAL_USE)
+        if (spUsePermission == PackageManager.PERMISSION_DENIED) {
+            stopSelf()
+            return
+        }
+
+        ServiceCompat.startForeground(this, 100, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+   }
+
+    override fun onCreate() {
+        handlerThread = HandlerThread("ServiceStartArguments", Process.THREAD_PRIORITY_BACKGROUND).apply {
+            start()
+        }
+
+        serviceLooper = handlerThread.looper
+        serviceHandler = MainHandler(serviceLooper)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Toast.makeText(this, "Starting the MainService", Toast.LENGTH_SHORT).show()
+
+        serviceHandler.obtainMessage().also { msg ->
+            msg.arg1 = startId
+            serviceHandler.sendMessage(msg)
+        }
+
+        startForeground()
+
+        // If we get killed, after returning from here, restart
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent): IBinder {
+        TODO("Return the communication channel to the service.")
+    }
+
+    override fun onDestroy() {
+        Toast.makeText(this, "The MainService has been gone", Toast.LENGTH_SHORT).show()
+    }
+}


### PR DESCRIPTION
This patch adds an empty service that runs in the foreground to the ML Inference Offloading App. The Service is launched by the
startForegroundService method in the onCreate callback of the Activity.

Signed-off-by: Wook Song <wook16.song@samsung.com>