### PR TITLE
Gradle/NNSApi: Configure nnstreamer-api, a Gradle subproject

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ tukaani-xz-plugin = "1.9"
 commons-compress-lib = "1.26.1"
 xyz-simple-git-plugin = "2.0.3"
 agp = "8.3.1"
+android-compile-sdk = "34"
 kotlin = "1.9.23"
 coreKtx = "1.12.0"
 junit = "4.13.2"
@@ -34,4 +35,5 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 [plugins]
 xyz-simple-git = { id = "xyz.ronella.simple-git", version.ref = "xyz-simple-git-plugin" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
+androidLibrary = { id = "com.android.library", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/nnstreamer-api/Android.mk
+++ b/nnstreamer-api/Android.mk
@@ -1,0 +1,47 @@
+include $(CLEAR_VARS)
+
+# nnstreamer_api
+LOCAL_PATH := $(call my-dir)
+LOCAL_MODULE := nnstreamer_api
+LOCAL_SHARED_LIBRARIES := gstreamer_android
+NNSTREAMER_API_OPTION := all
+
+# GStreamer
+include $(BUILD_SHARED_LIBRARY)
+
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+GSTREAMER_ROOT        := $(GSTREAMER_ROOT_ANDROID)/armv7
+else ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+GSTREAMER_ROOT        := $(GSTREAMER_ROOT_ANDROID)/arm64
+else ifeq ($(TARGET_ARCH_ABI),x86)
+GSTREAMER_ROOT        := $(GSTREAMER_ROOT_ANDROID)/x86
+else ifeq ($(TARGET_ARCH_ABI),x86_64)
+GSTREAMER_ROOT        := $(GSTREAMER_ROOT_ANDROID)/x86_64
+else
+$(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
+endif
+
+GSTREAMER_NDK_BUILD_PATH := $(GSTREAMER_ROOT)/share/gst-android/ndk-build/
+include $(ML_API_ROOT)/java/android/nnstreamer/src/main/jni/Android-gst-plugins.mk
+
+GST_BLOCKED_PLUGINS      := \
+        fallbackswitch livesync rsinter rstracers \
+        threadshare togglerecord cdg claxon dav1d rsclosedcaption \
+        ffv1 fmp4 mp4 gif hsv lewton rav1e json rspng regex textwrap textahead \
+        aws hlssink3 ndi rsonvif raptorq reqwest rsrtp rsrtsp webrtchttp rswebrtc uriplaylistbin \
+        rsaudiofx rsvideofx
+
+GSTREAMER_PLUGINS        := $(filter-out $(GST_BLOCKED_PLUGINS), $(GST_REQUIRED_PLUGINS))
+GSTREAMER_EXTRA_DEPS     := $(GST_REQUIRED_DEPS) glib-2.0 gio-2.0 gmodule-2.0
+GSTREAMER_EXTRA_LIBS     := $(GST_REQUIRED_LIBS) -liconv
+
+ifeq ($(NNSTREAMER_API_OPTION),all)
+GSTREAMER_EXTRA_LIBS += -lcairo
+endif
+
+GSTREAMER_INCLUDE_FONTS := no
+GSTREAMER_INCLUDE_CA_CERTIFICATES := no
+
+include $(GSTREAMER_NDK_BUILD_PATH)/gstreamer-1.0.mk
+
+$(call import-module, android/cpufeatures)

--- a/nnstreamer-api/Application.mk
+++ b/nnstreamer-api/Application.mk
@@ -1,0 +1,2 @@
+APP_PROJECT_PATH := $(call my-dir)/nnstreamer-api
+APP_STL := c++_shared

--- a/nnstreamer-api/build.gradle.kts
+++ b/nnstreamer-api/build.gradle.kts
@@ -1,0 +1,41 @@
+@file:Suppress("UnstableApiUsage")
+
+import kotlin.io.path.Path
+
+plugins {
+    alias(libs.plugins.androidLibrary)
+}
+
+val externalDirPath by rootProject.extra { rootDir.path + "/" + properties["dir.externals"] }
+
+android {
+    val pathExternals = findProperty("externalDirPath").toString()
+    val relativePathExternals = projectDir.toPath().relativize(Path(pathExternals))
+
+    namespace = "org.nnsuite.nnstreamer"
+    compileSdk = libs.versions.android.compile.sdk.get().toInt()
+    ndkVersion = "25.2.9519653"
+
+    defaultConfig {
+        minSdk = 21
+        externalNativeBuild {
+            ndkBuild {
+                abiFilters("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+                arguments(
+                        "NDK_PROJECT_PATH=./",
+                        "NDK_APPLICATION_MK=Application.mk",
+                        "GSTREAMER_JAVA_SRC_DIR=src/main/java",
+                        "GSTREAMER_ROOT_ANDROID=$relativePathExternals/gst-1.0-android-universal",
+                        "NNSTREAMER_ROOT=$relativePathExternals/nnstreamer",
+                        "ML_API_ROOT=$relativePathExternals/ml-api"
+                )
+                targets("nnstreamer_api")
+            }
+        }
+    }
+    externalNativeBuild {
+        ndkBuild {
+            path=file("./Android.mk")
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,4 @@ dependencyResolutionManagement {
 rootProject.name = "nnstreamer-android"
 
 include(":externals")
+include(":nnstreamer-api")


### PR DESCRIPTION
This patch configures a Gradle subproject, nnstreamer-api, that generates an AAR file to provide the NNStreamer Android API.
For the test purpose, only the universal GStreamer library for Android is currently included in the AAR file instead of the NNStreamer library.

Signed-off-by: Wook Song <wook16.song@samsung.com>

