### PR TITLE
Git: Add nnstreamer-edge as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = externals/ml-api
 	url = https://github.com/nnstreamer/api
 	branch = main
+[submodule "externals/nnstreamer-edge"]
+	path = externals/nnstreamer-edge
+	url = https://github.com/nnstreamer/nnstreamer-edge
+	branch = main


### PR DESCRIPTION
Currently, ML API requires nnstreamer-edge to build the Java API by default. For this reason, this patch adds nnstreamer-edge as a git submodule.

Signed-off-by: Wook Song <wook16.song@samsung.com>