### PR TITLE
Gradle: Add a workaround for java.lang.OutOfMemoryError

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.jvmargs=-Xmx4096M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 dir.externals=externals
 dir.downloadable=downloadable
 dir.gstAndroid=gst-1.0-android-universal


### PR DESCRIPTION
Gradle build is occasionally failed by "java.lang.OutOfMemoryError: Java heap space". This patch adds a workaround to avoid this error.

Signed-off-by: Wook Song <wook16.song@samsung.com>
