### PR TITLE
App/Gradle: Revise plugin dependencies to avoid build error

### DIFF
--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
+    id(libs.plugins.androidApplication.get().pluginId)
+    id(libs.plugins.jetbrainsKotlinAndroid.get().pluginId)
 }
 
 android {


### PR DESCRIPTION
This patch revises the plugin dependencies of the App to use plugin IDs instead of the alias, which includes specific version numbers. The multiple uses of the alias are likely to incur the following error:

The request for this plugin could not be satisfied because the plugin is already on the classpath with an unknown version, so compatibility cannot be checked.

Signed-off-by: Wook Song <wook16.song@samsung.com>
