### PR TITLE
Gradle: Fix build error in externals

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,3 +4,9 @@ plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
 }
+
+buildscript {
+    dependencies {
+        classpath(libs.tukaani.xz)
+    }
+}


### PR DESCRIPTION
This patch adds buildscript dependencies to fix build error in externals.