### PR TITLE
Gradle/Externals: Add tflite option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ build
 # Ignore 3rd party binaries
 /externals/downloadable
 /externals/gst-1.0-android-universal
+/externals/tensorflow-lite

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.jvmargs=-Xmx4096M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF
 dir.externals=externals
 dir.downloadable=downloadable
 dir.gstAndroid=gst-1.0-android-universal
+dir.tfliteAndroid=tensorflow-lite
 dir.nnstreamer=nnstreamer
 dir.mlApi=ml-api
 url.repo.nnstreamer=https://github.com/nnstreamer/nnstreamer

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 gstreamer = "1.24.0"
+tensorflowLite = "2.8.1"
 tukaani-xz-plugin = "1.9"
 commons-compress-lib = "1.26.1"
 xyz-simple-git-plugin = "2.0.3"


### PR DESCRIPTION
This patch adds tflite option in external gradle.
If gradle.properties file has `dir.tfliteAndroid` value, tflite library will be downloaded to externals repo.

needs : https://github.com/nnstreamer/api/pull/499
