### PR TITLE
Gradle/NNSApi: Copy aar file to external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ build
 # Ignore 3rd party binaries
 /externals/downloadable
 /externals/gst-1.0-android-universal
+/externals/libs

--- a/nnstreamer-api/build.gradle.kts
+++ b/nnstreamer-api/build.gradle.kts
@@ -92,5 +92,20 @@ android {
         named("preBuild") {
             dependsOn("genNnsSrc")
         }
+
+        build {
+            doLast{
+                copy {
+                    val srcAarPath = project.projectDir.toPath().resolve("build/outputs/aar")
+                    val outAarPath = externalDirPath.resolve("libs").apply {
+                        createDirectories()
+                    }
+
+                    from(srcAarPath)
+                    include("*-debug.aar")
+                    into(outAarPath)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This patch adds task in build.gradle.kts to copy aar file.
Copied aar file will be used by other modules.