### PR TITLE
Fix no space left on device error in github action.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,9 +25,9 @@ jobs:
         distribution: 'temurin'
         java-version: 17
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        arguments: build
+      uses: gradle/actions/setup-gradle@v3
+    - name: Run build
+      run: ./gradlew build
     - name: Upload nnstreamer-api aar
       uses: actions/upload-artifact@v4
       with:

--- a/externals/build.gradle.kts
+++ b/externals/build.gradle.kts
@@ -83,6 +83,9 @@ tasks {
         into(gstAndroidPath)
 
         dependsOn("prepareDownloadable")
+        doLast {
+            Path("$downloadablePath/$gstTarFileName").deleteIfExists()
+        }
     }
 
     register("initGitSubmodules", GitTask::class) {


### PR DESCRIPTION
This PR removes copied gstreamer tar file in external/build.gradle.kts
Remained tar file causes no space left error. (2.6G gstreamer-1.0-android-universal-1.24.0.tar)
Also, gradle-build-action is deprecated.