### PR TITLE
Externals/Gradle: Add a Gradle task for cleaning all of the generated 

### DIFF
--- a/externals/build.gradle.kts
+++ b/externals/build.gradle.kts
@@ -161,9 +161,22 @@ tasks {
         args = listOf("git checkout .") // The git command arguments
         dependsOn("updateGitSubmodules")
     }
+
+    register("cleanAll", Delete::class) {
+        delete(downloadablePath)
+        for (downloadble in downloadables) {
+            val (_, targetDir, _) = downloadble
+
+            delete(projectDir.toPath().resolve(targetDir))
+        }
+
+        dependsOn("clean")
+    }
 }
 
 tasks.named("build") {
     dependsOn("copyFromTar")
     dependsOn("checkoutGitSubmodules")
 }
+
+


### PR DESCRIPTION
This patch adds a Gradle task that cleans all of the generated directories and files.

Signed-off-by: Wook Song <wook16.song@samsung.com>