### PR TITLE
Api/Gradle: Revert the location for NNS Java source code generation

### DIFF
--- a/nnstreamer-api/build.gradle.kts
+++ b/nnstreamer-api/build.gradle.kts
@@ -61,8 +61,9 @@ android {
     }
 
     val genNnsSrc = tasks.register("genNnsSrc", Copy::class) {
-        val srcDirPath = externalDirPath.resolve("ml-api/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer")
-        val outDirPath = project.projectDir.toPath().resolve("src/main/java/org/nnsuite/nnstreamer/java").apply {
+        val commonSuffix = "src/main/java/org/nnsuite/nnstreamer"
+        val srcDirPath = externalDirPath.resolve("ml-api/java/android/nnstreamer").resolve(commonSuffix)
+        val outDirPath = project.projectDir.toPath().resolve(commonSuffix).apply {
             createDirectories()
         }
 


### PR DESCRIPTION
Instead of src/main/java/$NAMESPACE/java, src/main/java/$NAMESPACE is the right location for the NNS API Java source code generation. This patch reverts such change to the right one.

Signed-off-by: Wook Song <wook16.song@samsung.com>