### PR TITLE
Externals/Gradle: Remove unnecessary code snippets

### DIFF
--- a/externals/build.gradle.kts
+++ b/externals/build.gradle.kts
@@ -11,19 +11,6 @@ apply {
     plugin(libs.plugins.xyz.simple.git.get().pluginId)
 }
 
-buildscript {
-    dependencies {
-        classpath(libs.commons.compress)
-        classpath(libs.tukaani.xz)
-    }
-
-    repositories {
-        gradlePluginPortal()
-        google()
-        mavenCentral()
-    }
-}
-
 tasks {
     fun downloadFile(url: URL, outputFileName: String) {
         url.openStream().use {
@@ -178,5 +165,3 @@ tasks.named("build") {
     dependsOn("copyFromTar")
     dependsOn("checkoutGitSubmodules")
 }
-
-


### PR DESCRIPTION
This patch removes unnecessary code snippets in the Gradle build script of the externals module.

Signed-off-by: Wook Song <wook16.song@samsung.com>