### PR TITLE
Externals/Gradle: Update trivial things

### DIFF
--- a/externals/build.gradle.kts
+++ b/externals/build.gradle.kts
@@ -6,9 +6,9 @@ import kotlin.io.path.Path
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
 import xyz.ronella.gradle.plugin.simple.git.task.*
 
-apply {
-    plugin("base")
-    plugin(libs.plugins.xyz.simple.git.get().pluginId)
+plugins {
+    base
+    id(libs.plugins.xyz.simple.git.get().pluginId)
 }
 
 tasks {
@@ -26,7 +26,7 @@ tasks {
         File(filePath).outputStream().use { fileOutput -> this.copyTo(fileOutput) }
     }
 
-    val downloadablePath = Path("${projectDir}/${project.properties["dir.downloadable"].toString()}")
+    val downloadablePath = Path("$projectDir/${project.properties["dir.downloadable"]}")
 
     //FIXME Revise project.properties
     // - remove dir.gstAndroid/dir.tfliteAndroid if not necessary

--- a/externals/build.gradle.kts
+++ b/externals/build.gradle.kts
@@ -56,12 +56,13 @@ tasks {
 
     // TensorFlow Lite
     val tfliteVersion = libs.versions.tensorflowLite.get()
+    val enabledTFLite = project.hasProperty("dir.tfliteAndroid")
     val tfliteDownloadable =
         Downloadable(
             "tensorflow-lite-$tfliteVersion.tar",
             project.properties["dir.tfliteAndroid"].toString(),
             "https://raw.githubusercontent.com/nnstreamer/nnstreamer-android-resource/master/external",
-            true,
+            enabledTFLite,
             ".xz"
         )
     downloadables.add(tfliteDownloadable)


### PR DESCRIPTION
This PR includes the following commits to update several trivial things in externals/build.gradle.kts.
- Externals/Gradle: Apply plugins using the modern way
- Externals/Gradle: Use dir.tfliteAndroid as an option to enable TFLite

Signed-off-by: Wook Song <wook16.song@samsung.com>
