### PR TITLE
Api/Gradle: Eliminate hard-coded path strings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,8 @@ dir.downloadable=downloadable
 dir.gstAndroid=gst-1.0-android-universal
 dir.tfliteAndroid=tensorflow-lite
 dir.nnstreamer=nnstreamer
+dir.nnstreamerEdge=nnstreamer-edge
 dir.mlApi=ml-api
-url.repo.nnstreamer=https://github.com/nnstreamer/nnstreamer
-url.repo.mlApi=https://github.com/nnstreamer/api
 android.useAndroidX=true
 android.enableJetifier=true
 #NOTE: Do not change the lines above

--- a/nnstreamer-api/build.gradle.kts
+++ b/nnstreamer-api/build.gradle.kts
@@ -1,6 +1,5 @@
 @file:Suppress("UnstableApiUsage")
 
-import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
 
 plugins {
@@ -11,7 +10,17 @@ android {
     val externalDirPath by rootProject.extra {
         project.rootDir.toPath().resolve(properties["dir.externals"].toString())
     }
-    val mlApiRootPath = externalDirPath.resolve("ml-api")
+    val gstDir = properties["dir.gstAndroid"].toString()
+    val gstRootPath = externalDirPath.resolve(gstDir)
+
+    val nnsDir = properties["dir.nnstreamer"].toString()
+    val nnsRootPath = externalDirPath.resolve(nnsDir)
+
+    val nnsEdgeDir = properties["dir.nnstreamerEdge"].toString()
+    val nnsEdgeRootPath = externalDirPath.resolve(nnsEdgeDir)
+
+    val mlApiDir = properties["dir.mlApi"].toString()
+    val mlApiRootPath = externalDirPath.resolve(mlApiDir)
     val mlApiNNSJniPath = mlApiRootPath.resolve("java/android/nnstreamer/src/main/jni")
 
     namespace = "org.nnsuite.nnstreamer"
@@ -26,17 +35,19 @@ android {
                 arguments("NDK_PROJECT_PATH=./",
                         "NDK_APPLICATION_MK=$mlApiNNSJniPath/Application.mk",
                         "GSTREAMER_JAVA_SRC_DIR=src/main/java",
-                        "GSTREAMER_ROOT_ANDROID=$externalDirPath/gst-1.0-android-universal",
-                        "NNSTREAMER_ROOT=$externalDirPath/nnstreamer",
-                        "NNSTREAMER_EDGE_ROOT=$externalDirPath/nnstreamer-edge",
+                        "GSTREAMER_ROOT_ANDROID=$gstRootPath",
+                        "NNSTREAMER_ROOT=$nnsRootPath",
+                        "NNSTREAMER_EDGE_ROOT=$nnsEdgeRootPath",
                         "ML_API_ROOT=$mlApiRootPath"
                 )
                 targets("nnstreamer-native")
 
                 if (project.hasProperty("dir.tfliteAndroid")) {
+                    val tfliteDir = properties["dir.tfliteAndroid"].toString()
+                    val tfliteRootPath = externalDirPath.resolve(tfliteDir)
                     val tfliteVersion = libs.versions.tensorflowLite.get()
 
-                    arguments("TFLITE_ROOT_ANDROID=$externalDirPath/tensorflow-lite")
+                    arguments("TFLITE_ROOT_ANDROID=$tfliteRootPath")
                     arguments("TFLITE_VERSION=$tfliteVersion")
                 }
             }


### PR DESCRIPTION
This patch replaces several hard-coded path strings with the values from the gradle.properties file.

Signed-off-by: Wook Song <wook16.song@samsung.com>
