### PR TITLE
Gradle: Add a Gradle task that triggers cleanAll recursively

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,3 +10,10 @@ buildscript {
         classpath(libs.tukaani.xz)
     }
 }
+
+tasks {
+    register("cleanAll") {
+        dependsOn("nnstreamer-api:cleanAll")
+        dependsOn("externals:cleanAll")
+    }
+}


### PR DESCRIPTION
This patch adds a Gradle task that recursively triggers the cleanAll tasks to the build.gradle.kts file in the project root directory.

Signed-off-by: Wook Song <wook16.song@samsung.com>