### PR TITLE
App/Service: Revise the getIpAddress method

### DIFF
--- a/ml_inference_offloading/src/main/AndroidManifest.xml
+++ b/ml_inference_offloading/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
-    <application
+    <application android:name=".App"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/App.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/App.kt
@@ -1,0 +1,18 @@
+package ai.nnstreamer.ml.inference.offloading
+
+import android.app.Application
+import android.content.Context
+
+class App : Application() {
+    init{
+        instance = this
+    }
+
+    companion object {
+        lateinit var instance: App
+
+        fun context() : Context {
+            return instance.applicationContext
+        }
+    }
+}

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.net.ConnectivityManager
 import android.os.Binder
+import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.IBinder
@@ -53,6 +54,27 @@ class MainService : Service() {
 
     private val TAG = "MainService"
     private val binder = LocalBinder()
+    private val isRunningOnEmulator: Boolean
+        get() = (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+                || Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.HARDWARE.contains("goldfish")
+                || Build.HARDWARE.contains("ranchu")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("Android SDK built for x86")
+                || Build.MANUFACTURER.contains("Genymotion")
+                || Build.PRODUCT.contains("sdk_google")
+                || Build.PRODUCT.contains("google_sdk")
+                || Build.PRODUCT.contains("sdk")
+                || Build.PRODUCT.contains("sdk_x86")
+                || Build.PRODUCT.contains("sdk_gphone64_arm64")
+                || Build.PRODUCT.contains("vbox86p")
+                || Build.PRODUCT.contains("emulator")
+                || Build.PRODUCT.contains("simulator")
+                || Build.PRODUCT == "sdk_gphone64_arm64"
+                || Build.FINGERPRINT == "robolectric"
+                || Build.MANUFACTURER.contains("Geny")
     private lateinit var serviceHandler : MainHandler
     private lateinit var serviceLooper : Looper
     private lateinit var handlerThread: HandlerThread


### PR DESCRIPTION
This patch revises the getIpAddress method to return the proper localhost address corresponding to the emulator or the real target. Moreover, the platform-type variables are eliminated.

Signed-off-by: Wook Song <wook16.song@samsung.com>