### PR TITLE
Externals/Gradle: Make git submodules track the remote branch

### DIFF
--- a/externals/build.gradle.kts
+++ b/externals/build.gradle.kts
@@ -138,17 +138,17 @@ tasks {
     //TODO Use a specific commit ID or TAG
     register("initGitSubmodules", GitTask::class) { command = "submodule init" }
 
-    register("updateGitSubmodules", GitTask::class) {
-        command = "submodule update"
-
-        dependsOn("initGitSubmodules")
-    }
-
     register("checkoutGitSubmodules", GitTask::class) {
         command = "submodule foreach"
         args = listOf("git checkout .") // The git command arguments
-        dependsOn("updateGitSubmodules")
+        dependsOn("initGitSubmodules")
     }
+
+    register("updateGitSubmodules", GitTask::class) {
+        command = "submodule update --remote --recursive"
+        dependsOn("checkoutGitSubmodules")
+    }
+
 
     register("cleanAll", Delete::class) {
         delete(downloadablePath)
@@ -164,5 +164,5 @@ tasks {
 
 tasks.named("build") {
     dependsOn("copyFromTar")
-    dependsOn("checkoutGitSubmodules")
+    dependsOn("updateGitSubmodules")
 }


### PR DESCRIPTION
To make git submodules track the remote branch, this patch updates the Gradle build script of the subproject, "externals".

Signed-off-by: Wook Song <wook16.song@samsung.com>
