### PR TITLE
Externals/Gradle: Reorder the sequence of task execution

### DIFF
--- a/externals/build.gradle.kts
+++ b/externals/build.gradle.kts
@@ -197,6 +197,7 @@ tasks {
         }
 
         dependsOn("clean")
+        mustRunAfter(":nnstreamer-api:cleanAll")
     }
 }
 


### PR DESCRIPTION
This fixes a bug in the Gradle task named 'cleanAll' by reordering the sequence of task execution.

Signed-off-by: Wook Song <wook16.song@samsung.com>