### PR TITLE
Gradle/App: Update the target JVM to 17 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ dir.tfliteAndroid=tensorflow-lite
 dir.nnstreamer=nnstreamer
 dir.nnstreamerEdge=nnstreamer-edge
 dir.mlApi=ml-api
+kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=true
 #NOTE: Do not change the lines above

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,42 +1,44 @@
 [versions]
-gstreamer = "1.24.0"
-tensorflowLite = "2.16.1"
-tukaani-xz-plugin = "1.9"
-commons-compress-lib = "1.26.1"
-xyz-simple-git-plugin = "2.0.3"
-agp = "8.3.1"
+activityCompose = "1.8.2"
 android-compile-sdk = "34"
-kotlin = "1.9.23"
+agp = "8.3.1"
+commons-compress-lib = "1.26.1"
+composeBom = "2024.04.00"
 coreKtx = "1.12.0"
+espressoCore = "3.5.1"
+gstreamer = "1.24.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
-espressoCore = "3.5.1"
+kotlin = "1.9.23"
 lifecycleRuntimeKtx = "2.7.0"
-activityCompose = "1.8.2"
-composeBom = "2024.04.00"
+recyclerview = "1.3.2"
 robolectric = "4.12.2"
+tensorflowLite = "2.16.1"
+tukaani-xz-plugin = "1.9"
+xyz-simple-git-plugin = "2.0.3"
 
 [libraries]
-tukaani-xz ={ group = "org.tukaani", name= "xz", version.ref =  "tukaani-xz-plugin" }
 commons-compress = { group = "org.apache.commons", name= "commons-compress", version.ref = "commons-compress-lib" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+tukaani-xz ={ group = "org.tukaani", name= "xz", version.ref =  "tukaani-xz-plugin" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
-xyz-simple-git = { id = "xyz.ronella.simple-git", version.ref = "xyz-simple-git-plugin" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+xyz-simple-git = { id = "xyz.ronella.simple-git", version.ref = "xyz-simple-git-plugin" }

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -30,11 +30,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -55,22 +55,28 @@ android {
 }
 
 dependencies {
+    implementation(project(":nnstreamer-api"))
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.material3)
+    implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    implementation(project(":nnstreamer-api"))
-    implementation("androidx.recyclerview:recyclerview:1.3.2")
+
+    // Debug
+    debugImplementation(libs.androidx.ui.test.manifest)
+    debugImplementation(libs.androidx.ui.tooling)
+
+    // Test
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
+
+
 }


### PR DESCRIPTION
This PR revises some configurations of the build scripts and environments before introducing the Room Persistence library to the project as follows:
  - Gradle/App: Revise Project.dependencies for the App
  - Gradle/App: Update the target JVM to 17
  - Gradle: Declare code style for kotlin

Signed-off-by: Wook Song <wook16.song@samsung.com>