### PR TITLE
App/FileProvider: Introduce FileProvider for serving ML model files 

### DIFF
--- a/ml_inference_offloading/src/main/AndroidManifest.xml
+++ b/ml_inference_offloading/src/main/AndroidManifest.xml
@@ -33,6 +33,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+                android:authorities="${applicationId}.fileprovider"
+                android:exported="false"
+                android:grantUriPermissions="true"
+                android:name="androidx.core.content.FileProvider">
+            <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/ml_inference_offloading/src/main/res/xml/file_paths.xml
+++ b/ml_inference_offloading/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-files-path
+            name="models"
+            path="models" />
+</paths>


### PR DESCRIPTION
This patch introduces an Android component, FileProvider (a subclass of ContentProvider), that serves ML model files to other components.

Signed-off-by: Wook Song <wook16.song@samsung.com>