### PR TITLE
App/Activity: Let the FileProvider load bundled model files

### DIFF
--- a/ml_inference_offloading/src/main/AndroidManifest.xml
+++ b/ml_inference_offloading/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
                 android:authorities="${applicationId}.fileprovider"
                 android:exported="false"
                 android:grantUriPermissions="true"
-                android:name="androidx.core.content.FileProvider">
+                android:name=".providers.ModelFileProvider">
             <meta-data
                     android:name="android.support.FILE_PROVIDER_PATHS"
                     android:resource="@xml/file_paths" />

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
@@ -1,0 +1,56 @@
+package ai.nnstreamer.ml.inference.offloading.providers
+
+import ai.nnstreamer.ml.inference.offloading.R
+import android.content.Context
+import androidx.core.content.FileProvider
+import java.io.FileOutputStream
+import java.io.IOException
+
+class ModelFileProvider : FileProvider(R.xml.file_paths) {
+    companion object {
+        val assetPaths = listOf("models")
+    }
+
+    private fun copyAssetsToExternal(ctx: Context, path: String) {
+        val resAssets = ctx.resources.assets
+        val externalDir = ctx.getExternalFilesDir(null)?.resolve(path)
+            ?: throw IOException("Failed to resolve $path in the App's private external storage")
+
+        try {
+            if (!externalDir.isDirectory && !externalDir.mkdir()) {
+                throw IOException("Failed to create $externalDir")
+            }
+        } catch (e: SecurityException) {
+            val msg = e.message ?: "none"
+
+            throw IOException("Failed to access $externalDir for the security reason (details: $msg)")
+        }
+
+
+        resAssets.list(path)?.run {
+            filterNotNull().onEach { file ->
+                val os = FileOutputStream(externalDir.resolve(file))
+
+                resAssets.open("$path/$file").use { stream ->
+                    stream.copyTo(os)
+                }
+            }
+        }
+    }
+
+    @Override
+    override fun onCreate(): Boolean {
+        context?.run {
+            assetPaths.onEach { path ->
+                try {
+                    copyAssetsToExternal(this, path)
+                } catch (e: Exception) {
+                    throw RuntimeException("Failed to preload $path in the APK's assets directory")
+                }
+            }
+        }
+
+        return super.onCreate()
+    }
+
+}

--- a/ml_inference_offloading/src/test/java/ai/nnstreamer/ml/inference/offloading/ActivityUnitTest.kt
+++ b/ml_inference_offloading/src/test/java/ai/nnstreamer/ml/inference/offloading/ActivityUnitTest.kt
@@ -1,8 +1,7 @@
 package ai.nnstreamer.ml.inference.offloading
 
-
+import ai.nnstreamer.ml.inference.offloading.providers.ModelFileProvider
 import androidx.recyclerview.widget.RecyclerView
-
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,13 +12,22 @@ import org.robolectric.RobolectricTestRunner
 class ActivityUnitTest {
     @Test
     fun testModelListLength() {
-        val activityController = Robolectric.buildActivity(MainActivity::class.java).create()
-        val activity = activityController.get()
-        val recyclerview = activity.findViewById<RecyclerView>(R.id.model_list)
-        val adapter = recyclerview.adapter
+        val testModelFileProvider =
+            Robolectric.buildContentProvider(ModelFileProvider::class.java).create().get()
+        val activity = testModelFileProvider?.let {
+            val activityController =
+                Robolectric.buildActivity(MainActivity::class.java).create()
 
-        adapter?.run {
-            assertEquals(2, adapter.itemCount)
+            activityController.get()
+        }
+
+        activity?.run {
+            val recyclerview = this.findViewById<RecyclerView>(R.id.model_list)
+            val numModelsInAssets =
+                this.applicationContext.resources.assets.list("models")?.size ?: -1
+            val numModels = recyclerview.adapter?.itemCount ?: 0
+
+            assertEquals(numModelsInAssets, numModels)
         }
     }
 }


### PR DESCRIPTION
This patch makes the ModelFileProvider pre-load the model files, which are packaged into the APK file. According to this change, a test case for verifying the number of models preloaded has also been updated.
Signed-off-by: Wook Song <wook16.song@samsung.com>