### PR TITLE
App/Activity: Use other/tensors in private external models

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
@@ -114,9 +114,9 @@ class MainActivity : ComponentActivity() {
                         val mobileNet =
                             File("$privateExternalModels/$it")
                         val mobileNetFilter =
-                            "other/tensor,format=static,dimension=(string)3:224:224:1,type=uint8,framerate=0/1 ! " +
+                            "other/tensors,num_tensors=1,format=static,dimensions=(string)3:224:224:1,types=uint8,framerate=0/1 ! " +
                                     "tensor_filter framework=tensorflow-lite model=" + mobileNet.absolutePath + " ! " +
-                                    "other/tensor,format=static,dimension=(string)1001:1,type=uint8,framerate=0/1"
+                                    "other/tensors,num_tensors=1,format=static,dimensions=(string)1001:1,types=uint8,framerate=0/1"
                         val mobileNetInfo = ModelInfo("MobileNet", mobileNetFilter)
                         modelList.add(mobileNetInfo)
                     }


### PR DESCRIPTION
This patch changes tensor format from other/tensor to other/tensors. other/tensor is obsoleted.