### PR TITLE
Providers/ModelFile: Copy model files using a separate thread 

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
@@ -37,14 +37,12 @@ class ModelFileProvider : FileProvider(R.xml.file_paths) {
             throw IOException("Failed to access $externalDir for the security reason (details: $msg)")
         }
 
-
-        resAssets.list(path)?.run {
-            filterNotNull().onEach { file ->
-                val os = FileOutputStream(externalDir.resolve(file))
-
-                resAssets.open("$path/$file").use { stream ->
-                    stream.copyTo(os)
-                }
+        resAssets.list(path)?.filterNotNull()?.takeWhile {
+            // Copy the bundled asset files if they do not exist in the private external storage
+            !externalDir.resolve(it).exists()
+        }?.onEach { name ->
+            resAssets.open("$path/$name").use { stream ->
+                stream.copyTo(FileOutputStream(externalDir.resolve(name)))
             }
         }
     }


### PR DESCRIPTION
This PR improves the ModelFileProvider;
 - to copy model files bundled in the App package using a separate thread 
 - copy the model files only if the targets do not exist

Signed-off-by: Wook Song <wook16.song@samsung.com>