### PR TITLE
App/Data: Use index on foreign key

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/OffloadingService.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/OffloadingService.kt
@@ -2,6 +2,7 @@ package ai.nnstreamer.ml.inference.offloading.data
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.nnsuite.nnstreamer.Pipeline
 
@@ -13,6 +14,9 @@ import org.nnsuite.nnstreamer.Pipeline
             parentColumns = ["uid"],
             childColumns = ["modelId"]
         ),
+    ],
+    indices = [
+        Index("modelId")
     ]
 )
 data class OffloadingService(


### PR DESCRIPTION
This patch adds index on OffloadingService's foreigh key.
If we do not use it, it may trigger full table scans whenever parent table is modified.

resolves : #64 