### PR TITLE
App/Service: Close all the pipelines when service is destroyed

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
@@ -238,6 +238,15 @@ class MainService : Service() {
     }
 
     override fun onDestroy() {
+        serviceMap.forEach { service ->
+            val pipeline = service.value.pipeline
+            pipeline.stop()
+            pipeline.close()
+            CoroutineScope(Dispatchers.IO).launch {
+                offloadingServiceRepositoryImpl.deleteOffloadingService(service.key)
+            }
+        }
+        serviceMap.clear()
         Toast.makeText(this, "The MainService has been gone", Toast.LENGTH_SHORT).show()
     }
 


### PR DESCRIPTION
This patch makes service to close all the pipelines when `onDestroyed`.
The pipelines could not work properly when the service is destroyed.
So it is necessary to explicitly close them and remove if from the database.

Related to : #63