### PR TITLE
App/Data: Introduce Preferences DataStore

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,12 @@
 activityCompose = "1.8.2"
 android-compile-sdk = "34"
 agp = "8.3.1"
+appcompat = "1.7.0"
 commons-compress-lib = "1.26.1"
 composeBom = "2024.04.00"
 coreKtx = "1.12.0"
 dagger = "2.51.1"
+datastore = "1.1.1"
 espressoCore = "3.5.1"
 google-devtools-ksp = "1.9.23-1.0.19"
 gstreamer = "1.24.0"
@@ -29,8 +31,11 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 tukaani-xz = { group = "org.tukaani", name = "xz", version.ref = "tukaani-xz-plugin" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-datastore-core-android = { group = "androidx.datastore", name = "datastore-core-android", version.ref = "datastore" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(project(":nnstreamer-api"))
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.material3)
@@ -72,6 +73,10 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
+
+    // DataStore
+    implementation(libs.androidx.datastore.core.android)
+    implementation(libs.androidx.datastore.preferences)
 
     // Dagger
     implementation(libs.dagger)

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStore.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStore.kt
@@ -1,0 +1,11 @@
+package ai.nnstreamer.ml.inference.offloading.data
+
+import androidx.datastore.preferences.core.intPreferencesKey
+
+interface PreferencesDataStore {
+    suspend fun getIncrementalCounter(): Int
+
+    object PreferencesKey {
+        val PREF_INC_CNT = intPreferencesKey("incrementalCounter")
+    }
+}

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStoreImpl.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStoreImpl.kt
@@ -1,0 +1,25 @@
+package ai.nnstreamer.ml.inference.offloading.data
+
+import ai.nnstreamer.ml.inference.offloading.data.PreferencesDataStore.PreferencesKey.PREF_INC_CNT
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class PreferencesDataStoreImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : PreferencesDataStore {
+    override suspend fun getIncrementalCounter(): Int {
+        dataStore.edit {
+            it[PREF_INC_CNT] = dataStore.data.map { preferences ->
+                (preferences[PREF_INC_CNT]?.plus(1)) ?: 0
+            }.first()
+        }
+
+        return dataStore.data.map { preferences ->
+            preferences[PREF_INC_CNT] ?: 0
+        }.first()
+    }
+}

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/di/AppComponent.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/di/AppComponent.kt
@@ -10,7 +10,7 @@ import dagger.Component
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [DatabaseModule::class])
+@Component(modules = [DatabaseModule::class, DataStoreModule::class])
 interface AppComponent {
     @Component.Factory
     interface Factory {

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/di/DataStoreModule.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/di/DataStoreModule.kt
@@ -1,0 +1,42 @@
+package ai.nnstreamer.ml.inference.offloading.di
+
+import ai.nnstreamer.ml.inference.offloading.data.PreferencesDataStore
+import ai.nnstreamer.ml.inference.offloading.data.PreferencesDataStoreImpl
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+
+@Module
+object DataStoreModule {
+    private const val SHARED_PREFERENCES = "shared_preferences"
+
+    @Provides
+    @Singleton
+    fun provideDataStore(appContext: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler(
+                produceNewData = { emptyPreferences() }
+            ),
+            migrations = listOf(SharedPreferencesMigration(appContext, SHARED_PREFERENCES)),
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+            produceFile = { appContext.preferencesDataStoreFile(SHARED_PREFERENCES) }
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun providePreferencesStorage(dataStore: DataStore<Preferences>): PreferencesDataStore =
+        PreferencesDataStoreImpl(dataStore)
+}


### PR DESCRIPTION
While the ROOM library supports saving relatively large and complex data, the DataStore, which is replacing SharedPreferences, aims at saving small and light data. This patch introduces Preferences DataStore to track and maintain the App's status in the App-Wide scope.

Signed-off-by: Wook Song <wook16.song@samsung.com>