### PR TITLE
Gradle/Doc: Introduce an API documentation engine, Dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.googleDevtoolsKsp) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
+    alias(libs.plugins.jetbrainsDokka) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ composeBom = "2024.04.00"
 coreKtx = "1.12.0"
 dagger = "2.51.1"
 datastore = "1.1.1"
+dokka = "1.9.20"
 espressoCore = "3.5.1"
 google-devtools-ksp = "1.9.23-1.0.19"
 gstreamer = "1.24.0"
@@ -27,6 +28,8 @@ xyz-simple-git-plugin = "2.0.3"
 commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commons-compress-lib" }
 dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
+dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
+dokka-core = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 tukaani-xz = { group = "org.tukaani", name = "xz", version.ref = "tukaani-xz-plugin" }
@@ -53,9 +56,11 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-ui-test-junit4-android = { group = "androidx.compose.ui", name = "ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
 
+
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 googleDevtoolsKsp = { id = "com.google.devtools.ksp", version.ref = "google-devtools-ksp" }
+jetbrainsDokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 xyz-simple-git = { id = "xyz.ronella.simple-git", version.ref = "xyz-simple-git-plugin" }

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(libs.plugins.androidApplication.get().pluginId)
     id(libs.plugins.googleDevtoolsKsp.get().pluginId)
     id(libs.plugins.jetbrainsKotlinAndroid.get().pluginId)
+    id(libs.plugins.jetbrainsDokka.get().pluginId)
 }
 
 android {
@@ -97,4 +98,8 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.ui.test.junit4)
+
+    // Dokka
+    implementation(libs.dokka.base)
+    compileOnly(libs.dokka.core)
 }

--- a/nnstreamer-api/build.gradle.kts
+++ b/nnstreamer-api/build.gradle.kts
@@ -33,13 +33,14 @@ android {
         externalNativeBuild {
             ndkBuild {
                 abiFilters("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
-                arguments("NDK_PROJECT_PATH=./",
-                        "NDK_APPLICATION_MK=$mlApiNNSJniPath/Application.mk",
-                        "GSTREAMER_JAVA_SRC_DIR=src/main/java",
-                        "GSTREAMER_ROOT_ANDROID=$gstRootPath",
-                        "NNSTREAMER_ROOT=$nnsRootPath",
-                        "NNSTREAMER_EDGE_ROOT=$nnsEdgeRootPath",
-                        "ML_API_ROOT=$mlApiRootPath"
+                arguments(
+                    "NDK_PROJECT_PATH=./",
+                    "NDK_APPLICATION_MK=$mlApiNNSJniPath/Application.mk",
+                    "GSTREAMER_JAVA_SRC_DIR=src/main/java",
+                    "GSTREAMER_ROOT_ANDROID=$gstRootPath",
+                    "NNSTREAMER_ROOT=$nnsRootPath",
+                    "NNSTREAMER_EDGE_ROOT=$nnsEdgeRootPath",
+                    "ML_API_ROOT=$mlApiRootPath"
                 )
                 targets("nnstreamer-native")
 
@@ -57,8 +58,9 @@ android {
                          */
                         arguments("ENABLE_TF_LITE=$enableTflite")
                         if (!enableTflite) {
-                            val msg = "The property, 'dir.tfliteAndroid', is specified in 'gradle.properties', " +
-                                    "but failed to resolve it to $rootPath. TFLite support will be disabled."
+                            val msg =
+                                "The property, 'dir.tfliteAndroid', is specified in 'gradle.properties', " +
+                                        "but failed to resolve it to $rootPath. TFLite support will be disabled."
                             project.logger.lifecycle("WARNING: $msg")
                             return@also
                         }
@@ -76,8 +78,9 @@ android {
 
                         arguments("ENABLE_SNPE=$enableSnpe")
                         if (!enableSnpe) {
-                            val msg = "The property, 'dir.snpe', is specified in 'gradle.properties', " +
-                                    "but failed to resolve it to $rootPath. SNPE support will be disabled."
+                            val msg =
+                                "The property, 'dir.snpe', is specified in 'gradle.properties', " +
+                                        "but failed to resolve it to $rootPath. SNPE support will be disabled."
                             project.logger.lifecycle("WARNING: $msg")
                             return@also
                         }
@@ -97,16 +100,19 @@ android {
     }
     buildTypes {
         debug {
-            enableUnitTestCoverage=true
+            enableUnitTestCoverage = true
         }
         release {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
     externalNativeBuild {
         ndkBuild {
-            path=file(mlApiNNSJniPath.resolve("Android.mk"))
+            path = file(mlApiNNSJniPath.resolve("Android.mk"))
         }
     }
 
@@ -120,7 +126,8 @@ android {
 
     val genNnsSrc = tasks.register("genNnsSrc", Copy::class) {
         val commonSuffix = "src/main/java/org/nnsuite/nnstreamer"
-        val srcDirPath = externalDirPath.resolve("ml-api/java/android/nnstreamer").resolve(commonSuffix)
+        val srcDirPath =
+            externalDirPath.resolve("ml-api/java/android/nnstreamer").resolve(commonSuffix)
         val outDirPath = project.projectDir.toPath().resolve(commonSuffix).apply {
             createDirectories()
         }
@@ -170,8 +177,10 @@ android {
 
 afterEvaluate {
     listOf("Debug", "Release").forEach { buildType ->
-        val compileJavaWithJavacTask = project.getTasksByName("compile${buildType}JavaWithJavac", false)
-        val externalNativeBuildTask = project.getTasksByName("externalNativeBuild${buildType}", false)
+        val compileJavaWithJavacTask =
+            project.getTasksByName("compile${buildType}JavaWithJavac", false)
+        val externalNativeBuildTask =
+            project.getTasksByName("externalNativeBuild${buildType}", false)
 
         if (compileJavaWithJavacTask.size >= 1 && externalNativeBuildTask.size >= 1) {
             val compileJavaTask = compileJavaWithJavacTask.first()

--- a/nnstreamer-api/build.gradle.kts
+++ b/nnstreamer-api/build.gradle.kts
@@ -5,6 +5,7 @@ import kotlin.io.path.isDirectory
 
 plugins {
     id(libs.plugins.androidLibrary.get().pluginId)
+    id(libs.plugins.jetbrainsDokka.get().pluginId)
 }
 
 android {
@@ -172,6 +173,12 @@ android {
             }
             dependsOn("clean")
         }
+    }
+
+    dependencies {
+        // Dokka
+        implementation(libs.dokka.base)
+        compileOnly(libs.dokka.core)
     }
 }
 


### PR DESCRIPTION
This patch imports Dokka, an API documentation engine that supports automatic documentation generation.

Signed-off-by: Wook Song <wook16.song@samsung.com>

### How to generate HTML documents using Dokka
```bash
./gradlew dokkaHtml
```
See Also: [dokka-plugins](https://kotlinlang.org/docs/dokka-plugins.html), [Module documentation](https://kotlinlang.org/docs/dokka-module-and-package-docs.html)
