### PR TITLE
Providers/ModelFile: Replace misused takeWhile with filter

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
@@ -43,7 +43,7 @@ class ModelFileProvider : FileProvider(R.xml.file_paths) {
             throw IOException("Failed to access $externalDir for the security reason (details: $msg)")
         }
 
-        resAssets.list(path)?.filterNotNull()?.takeWhile {
+        resAssets.list(path)?.filterNotNull()?.filter {
             // Copy the bundled asset files if they do not exist in the private external storage
             !externalDir.resolve(it).exists()
         }?.onEach { name ->


### PR DESCRIPTION
This is a trivial patch to replace the misused method takeWhile with filter. Note that takeWhile returns the first element of the list that satisfies the given condition.

Signed-off-by: Wook Song <wook16.song@samsung.com>