### PR TITLE
App/Data: Update the Model entity

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ datastore = "1.1.1"
 dokka = "1.9.20"
 espressoCore = "3.5.1"
 google-devtools-ksp = "1.9.23-1.0.19"
+gson = "2.11.0"
 gstreamer = "1.24.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
@@ -30,6 +31,7 @@ dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 dokka-core = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 tukaani-xz = { group = "org.tukaani", name = "xz", version.ref = "tukaani-xz-plugin" }

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
     implementation(libs.androidx.datastore.core.android)
     implementation(libs.androidx.datastore.preferences)
 
+    // For TypeConverters
+    implementation(libs.gson)
+
     // Dagger
     implementation(libs.dagger)
     ksp(libs.dagger.compiler)

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/AppDatabase.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/AppDatabase.kt
@@ -4,8 +4,47 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+inline fun <reified T> Gson.fromJson(json: String): T =
+    fromJson<T>(json, object : TypeToken<T>() {}.type)
+
+class StringMapConverter {
+    @TypeConverter
+    fun fromStringToStringMap(map: Map<String, String>): String {
+        return Gson().toJson(map)
+    }
+
+    @TypeConverter
+    fun toStringToStringMap(str: String): Map<String, String> {
+        return try {
+            Gson().fromJson<Map<String, String>>(str)
+        } catch (e: Exception) {
+            mapOf()
+        }
+    }
+
+    @TypeConverter
+    fun fromStringToStringListMap(map: Map<String, List<String>>): String {
+        return Gson().toJson(map)
+    }
+
+    @TypeConverter
+    fun toStringToStringListMap(str: String): Map<String, List<String>> {
+        return try {
+            Gson().fromJson<Map<String, List<String>>>(str)
+        } catch (e: Exception) {
+            mapOf()
+        }
+    }
+}
 
 @Database(entities = [Model::class, OffloadingService::class], version = 1, exportSchema = false)
+@TypeConverters(StringMapConverter::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun modelDao(): ModelDao
     abstract fun offloadingServiceDao(): OffloadingServiceDao

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Model.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Model.kt
@@ -1,12 +1,89 @@
 package ai.nnstreamer.ml.inference.offloading.data
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import org.json.JSONObject
+import java.io.File
 
 @Entity(tableName = "models")
 data class Model(
-    @PrimaryKey(autoGenerate = true)
+    @PrimaryKey
     val uid: Int = 0,
-    // TODO: Fill in the information based on pre-defined config file
     val name: String,
-)
+) {
+    constructor(
+        uid: Int,
+        name: String,
+        jsonObject: JSONObject = JSONObject(),
+        optionalJsonObject: JSONObject = JSONObject()
+    ) : this(uid, name) {
+        // TODO: The following is the parser for "single", which is a legacy conf
+        runCatching {
+            framework = jsonObject.getString("framework")
+        }.exceptionOrNull()
+
+        runCatching {
+            val modelArray = jsonObject.getJSONArray("model")
+            val modelPaths = mutableListOf<String>()
+
+            for (i in 0 until modelArray.length()) {
+                val model = modelArray.getString(i)
+
+                modelPaths.add(File(model).name)
+            }
+            models = modelPaths.joinToString(",")
+        }.exceptionOrNull()
+
+        listOf("input_info", "output_info").forEach { prop ->
+            runCatching {
+                val infoMap = mutableMapOf<String, MutableList<String>>(
+                    "type" to mutableListOf(),
+                    "dimension" to mutableListOf()
+                )
+
+                val info = jsonObject.getJSONArray(prop)
+
+                for (i in 0 until info.length()) {
+                    val obj = info.getJSONObject(i)
+
+                    infoMap.keys.forEach { key ->
+                        if (obj.has(key)) {
+                            infoMap[key]?.add(obj.getString(key))
+                        }
+                    }
+                }
+
+                when (prop) {
+                    "input_info" -> inputInfo = infoMap.toMap()
+                    "output_info" -> outputInfo = infoMap.toMap()
+                }
+            }.exceptionOrNull()
+        }
+
+        val optionalInformationMap = mutableMapOf<String, String>()
+
+        optionalJsonObject.keys().forEach { key ->
+            optionalInformationMap[key] = ""
+        }
+        runCatching {
+            optionalInformationMap.keys.forEach { key ->
+                optionalInformationMap[key] = optionalJsonObject.getString(key)
+            }
+        }.exceptionOrNull()
+
+        optionalInfo = optionalInformationMap
+    }
+
+
+    var framework: String = ""
+    var models: String = ""
+
+    @ColumnInfo(name = "input_info")
+    var inputInfo: Map<String, List<String>> = mapOf()
+
+    @ColumnInfo(name = "output_info")
+    var outputInfo: Map<String, List<String>> = mapOf()
+
+    var optionalInfo: Map<String, String> = mapOf()
+}


### PR DESCRIPTION
This PR updates the Model entity to support the Tizen ML model config file of the 'single' type. In detail, the Model entity includes Map<String, String> and Map<String, List<String> typed data so that a TypeConvert class that supports type conversion from those types to JSON strings is also added.

Signed-off-by: Wook Song <wook16.song@samsung.com>