### PR TITLE
Provider/Model: Support parsing model config files

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/providers/ModelFileProvider.kt
@@ -2,7 +2,9 @@ package ai.nnstreamer.ml.inference.offloading.providers
 
 import ai.nnstreamer.ml.inference.offloading.App
 import ai.nnstreamer.ml.inference.offloading.R
+import ai.nnstreamer.ml.inference.offloading.data.Model
 import ai.nnstreamer.ml.inference.offloading.data.ModelRepositoryImpl
+import ai.nnstreamer.ml.inference.offloading.data.PreferencesDataStoreImpl
 import android.content.Context
 import android.util.Log
 import androidx.core.content.FileProvider
@@ -11,7 +13,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.json.JSONTokener
+import java.io.File
 import java.io.FileOutputStream
+import java.io.FileReader
 import java.io.IOException
 import javax.inject.Inject
 
@@ -22,14 +29,19 @@ import javax.inject.Inject
  * storage and generating a URI for the specified model.
  *
  * @constructor Creates a ModelFileProvider.
- * @property modelsRepository The class that implements the repository pattern for the models.
- * @see ModelRepositoryImpl
+ * @property modelsRepository the class that implements the repository pattern for the models.
+ * @property preferencesDataStore the class that implements the [PreferencesDataStore] interface.
+ * @see [ModelRepositoryImpl]
+ * @see [PreferencesDataStoreImpl]
  */
 class ModelFileProvider : FileProvider(R.xml.file_paths) {
     private val logTag = "FileProvider"
 
     @Inject
     lateinit var modelsRepository: ModelRepositoryImpl
+
+    @Inject
+    lateinit var preferencesDataStore: PreferencesDataStoreImpl
 
     private lateinit var copyAssetsToExternalJob: Job
 
@@ -38,10 +50,42 @@ class ModelFileProvider : FileProvider(R.xml.file_paths) {
     }
 
     /**
+     * Parse a given model configuration file
+     *
+     * @param confAbsPath the absolute path to the model configuration file to parse.
+     * @return a map of the names to the JSON objects of the model configuration file.
+     */
+    private fun parseModelConf(confAbsPath: String): Map<String, JSONObject> {
+        val confFile = File(confAbsPath)
+        val jsonString = runCatching {
+            FileReader(confFile).buffered().use {
+                it.readText()
+            }
+        }.getOrNull()
+        val ret = mutableMapOf<String, JSONObject>()
+        // A configuration file of the "Single" type
+        val keys = Pair("single", "information")
+
+        jsonString?.run {
+            val jsonObject = JSONTokener(this).nextValue() as JSONObject
+
+            runCatching {
+                keys.toList().forEach { key ->
+                    if (jsonObject.has(key)) {
+                        ret[key] = jsonObject.getJSONObject(key)
+                    }
+                }
+            }.getOrNull()
+        }
+
+        return ret
+    }
+
+    /**
      * Copies the assets to the external storage.
      *
-     * @param ctx The context of the application.
-     * @param path The path to the specified external storage to copy the assets.
+     * @param ctx the context of the application.
+     * @param path the path to the specified external storage to copy the assets.
      */
     private fun copyAssetsToExternal(ctx: Context, path: String) {
         val resAssets = ctx.resources.assets
@@ -64,6 +108,24 @@ class ModelFileProvider : FileProvider(R.xml.file_paths) {
         }?.onEach { name ->
             resAssets.open("$path/$name").use { stream ->
                 stream.copyTo(FileOutputStream(externalDir.resolve(name)))
+                // TODO: Place the following code in the other proper location
+                if (name.endsWith("conf")) {
+                    val map = parseModelConf(externalDir.resolve(name).toString())
+                    val modelId = runBlocking {
+                        preferencesDataStore.getIncrementalCounter()
+                    }
+                    val model = Model(
+                        modelId,
+                        name.removeSuffix(".conf"),
+                        map.getOrDefault("single", JSONObject()),
+                        map.getOrDefault("information", JSONObject()),
+                    )
+
+                    // TODO: Need to check the Model entity's integrity
+                    CoroutineScope(Dispatchers.IO).launch {
+                        modelsRepository.insertModel(model)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This patch updates the ModelFileProvider component to parse model config files when it copies model files in the assets directory to the App's private external storage.

Signed-off-by: Wook Song <wook16.song@samsung.com>