### PR TITLE
App/Service: Update MainService to use pre-loaded model files 

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
@@ -55,7 +55,6 @@ class MainActivity : ComponentActivity() {
             }
             Column {
                 ButtonList(
-                    onCreateModel = { lifecycleScope.launch { mService?.createModels() } },
                     onLoadModel = { lifecycleScope.launch { mService?.loadModels() } }
                 )
                 ServiceList(

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/ui/components/ServiceUi.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/ui/components/ServiceUi.kt
@@ -12,13 +12,9 @@ import androidx.compose.ui.Modifier
 // TODO: This is a temporary function to create test buttons
 @Composable
 fun ButtonList(
-    onCreateModel: () -> Unit,
     onLoadModel: () -> Unit,
 ) {
     Column {
-        Button(onClick = { onCreateModel() }) {
-            Text("Create models")
-        }
         Button(onClick = { onLoadModel() }) {
             Text("Load models")
         }


### PR DESCRIPTION
This patch updates MainService and MainActivity to use pre-loaded model files by ModelFileProvider. These are temporary changes before revising ModelRepository APIs.

Signed-off-by: Wook Song <wook16.song@samsung.com>