### PR TITLE
App/Gradle: Configure DokkaTasks' options for customization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 buildscript {
     dependencies {
         classpath(libs.tukaani.xz)
+        classpath(libs.dokka.base)
     }
 }
 

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -1,3 +1,7 @@
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.DokkaBaseConfiguration
+import org.jetbrains.dokka.gradle.DokkaTask
+
 plugins {
     id(libs.plugins.androidApplication.get().pluginId)
     id(libs.plugins.googleDevtoolsKsp.get().pluginId)
@@ -52,6 +56,24 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+        }
+    }
+}
+
+tasks {
+    withType<DokkaTask>().configureEach {
+        pluginConfiguration<DokkaBase, DokkaBaseConfiguration> {
+            separateInheritedMembers = false
+            mergeImplicitExpectActualDeclarations = false
+        }
+
+        dokkaSourceSets.configureEach {
+            perPackageOption {
+                suppressInheritedMembers.set(true)
+                suppressObviousFunctions.set(false)
+                reportUndocumented.set(false)
+                skipEmptyPackages.set(true)
+            }
         }
     }
 }


### PR DESCRIPTION
This patch adds configurations for the options in DokkaTasks to the Gradle build script to allow customization of the documentation outputs.

Signed-off-by: Wook Song <wook16.song@samsung.com>