### PR TITLE
Data/KDoc: Add KDoc documentation comments for PreferencesDataStore

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStore.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStore.kt
@@ -2,9 +2,15 @@ package ai.nnstreamer.ml.inference.offloading.data
 
 import androidx.datastore.preferences.core.intPreferencesKey
 
+/**
+ * Preferences Data Store interface. This is used to store and retrieve data from the preferences file.
+ */
 interface PreferencesDataStore {
     suspend fun getIncrementalCounter(): Int
 
+    /**
+     * Preference keys for storing data in the preferences file. These keys are used to identify the data stored in the preferences file.
+     */
     object PreferencesKey {
         val PREF_INC_CNT = intPreferencesKey("incrementalCounter")
     }

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStoreImpl.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/PreferencesDataStoreImpl.kt
@@ -8,9 +8,21 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
+/**
+ * Implementation of [PreferencesDataStore] using [DataStore]<[Preferences]>.
+ * This class is responsible for implementing the abstract methods defined in [PreferencesDataStore].
+ *
+ * @property dataStore the [DataStore]<[Preferences]> instance used to store preferences.
+ */
 class PreferencesDataStoreImpl @Inject constructor(
     private val dataStore: DataStore<Preferences>
 ) : PreferencesDataStore {
+    /**
+     * Retrieve the incremental counter from the data store and increments it by 1.
+     * It then stores the incremented value back into the data store.
+     *
+     * @return the incremented counter value. If no previous value exists, it returns 0.
+     */
     override suspend fun getIncrementalCounter(): Int {
         dataStore.edit {
             it[PREF_INC_CNT] = dataStore.data.map { preferences ->


### PR DESCRIPTION
This patch adds KDoc documentation comments for the PreferencesDataStore and PreferencesDataStoreImpl classes.

Signed-off-by: Wook Song <wook16.song@samsung.com>
