### PR TITLE
Data/Model: Fix wrong format type

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Model.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Model.kt
@@ -169,7 +169,7 @@ data class Model(
         val outFormat = outputInfo["format"]?.let { getFormat(it) } ?: "static"
 
         val inTensors = getTensors(inputInfo["type"], inFormat)
-        val outTensors = getTensors(outputInfo["type"], inFormat)
+        val outTensors = getTensors(outputInfo["type"], outFormat)
 
         val inTypes = inputInfo["type"]?.let { getType(it) } ?: ""
         val outTypes = outputInfo["type"]?.let { getType(it) } ?: ""


### PR DESCRIPTION
This patch fixes wrong format type when get tensors.