### PR TITLE
App: Fix bugs related to loading models whenever the service is created

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ junitVersion = "1.1.5"
 kotlin = "1.9.23"
 kotlinPluginSerialization = "2.0.20"
 kotlinxSerializationJson = "1.6.3"
-lifecycleRuntimeKtx = "2.7.0"
+lifecycleRuntime = "2.7.0"
 recyclerview = "1.3.2"
 robolectric = "4.12.2"
 room = "2.6.1"
@@ -49,7 +49,8 @@ androidx-datastore-core-android = { group = "androidx.datastore", name = "datast
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntime" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "composeMaterial" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeMaterial" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.material.icons.core)
     implementation(libs.androidx.material.icons.extended)

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainActivity.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -230,8 +231,9 @@ class MainActivity : ComponentActivity() {
                                                         )
                                                     }
                                                 )
+                                                val offloadingServiceUiStates by mViewModel.services.collectAsStateWithLifecycle()
                                                 ServiceList(
-                                                    mViewModel.services.collectAsState().value,
+                                                    offloadingServiceUiStates,
                                                     onClickStart = { id ->
                                                         mService?.send(
                                                             Message.obtain(

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/MainService.kt
@@ -252,7 +252,6 @@ class MainService : Service() {
             HandlerThread("ServiceStartArguments", Process.THREAD_PRIORITY_BACKGROUND).apply {
                 start()
             }
-        this.applicationContext
 
         serviceLooper = handlerThread.looper
         serviceHandler = MainHandler(serviceLooper)
@@ -267,11 +266,6 @@ class MainService : Service() {
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Toast.makeText(this, "Starting the MainService", Toast.LENGTH_SHORT).show()
-
-        serviceHandler.obtainMessage().also { msg ->
-            msg.arg1 = startId
-            serviceHandler.sendMessage(msg)
-        }
 
         startForeground()
 


### PR DESCRIPTION
This PR removes unnecessary code in MainService to fix bugs related to loading models whenever the service is created. In addition, this changes the method for collecting the StateFlow of the OffloadingServiceUiStates to the one that is lifecycle-aware.

Signed-off-by: Wook Song <wook16.song@samsung.com>