### PR TITLE
Assets/Modles: Add llama2c configuration file

### DIFF
--- a/ml_inference_offloading/src/main/assets/models/README.md
+++ b/ml_inference_offloading/src/main/assets/models/README.md
@@ -1,0 +1,10 @@
+## Configuration files of ML model
+
+### mobilenet_v1_1.0_224_quant
+
+### yolov8s_float32
+
+### llama2c
+
+To run llama2c model, copy model.bin and tokenizer.bin file into this directory.
+You can download and train custom small sized model that can be executed on Android devices [here](https://github.com/karpathy/llama2.c/tree/master?tab=readme-ov-file#custom-tokenizers)

--- a/ml_inference_offloading/src/main/assets/models/llama2c.conf
+++ b/ml_inference_offloading/src/main/assets/models/llama2c.conf
@@ -1,0 +1,17 @@
+{
+    "single" :
+    {
+        "framework" : "llama2c",
+        "model" : ["llama2c.bin", "tokenizer.bin"],
+        "input_info" : [
+          {
+            "format" : "flexible"
+          }
+        ],
+        "output_info" : [
+          {
+            "type" : "uint8"
+          }
+        ]
+    }
+}


### PR DESCRIPTION
This patch adds llama2c configuration file.
model and tokenizer bin file have to be copied to assets directory to use llama2 conf.