### PR TITLE
App/Vision: Add a vision example that the exploits MLAgent Service

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,8 @@ tensorflowLite = "2.16.1"
 tukaani-xz-plugin = "1.9"
 uiTestJunit4Android = "1.6.8"
 xyz-simple-git-plugin = "2.0.3"
+cameraCore = "1.3.4"
+firebaseCrashlyticsBuildtools = "3.0.2"
 
 [libraries]
 commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commons-compress-lib" }
@@ -43,6 +45,12 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 tukaani-xz = { group = "org.tukaani", name = "xz", version.ref = "tukaani-xz-plugin" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "cameraCore" }
+androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "cameraCore" }
+androidx-camera-extensions = { module = "androidx.camera:camera-extensions", version.ref = "cameraCore" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraCore" }
+androidx-camera-video = { module = "androidx.camera:camera-video", version.ref = "cameraCore" }
+androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "cameraCore" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore-core-android = { group = "androidx.datastore", name = "datastore-core-android", version.ref = "datastore" }
@@ -68,6 +76,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-ui-test-junit4-android = { group = "androidx.compose.ui", name = "ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+firebase-crashlytics-buildtools = { group = "com.google.firebase", name = "firebase-crashlytics-buildtools", version.ref = "firebaseCrashlyticsBuildtools" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.material.icons.core)
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.material3)
@@ -99,6 +100,17 @@ dependencies {
     // Room
     implementation(libs.androidx.room.common)
     implementation(libs.androidx.room.runtime)
+
+    // Camera
+    implementation(libs.androidx.camera.view)
+    implementation(libs.androidx.camera.core)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.video)
+    implementation(libs.androidx.camera.view)
+    implementation(libs.androidx.camera.extensions)
+    implementation(libs.firebase.crashlytics.buildtools)
+
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
 

--- a/ml_inference_offloading/src/main/AndroidManifest.xml
+++ b/ml_inference_offloading/src/main/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-feature
+            android:name="android.hardware.camera"
+            android:required="false" />
+
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Classification.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Classification.kt
@@ -1,0 +1,3 @@
+package ai.nnstreamer.ml.inference.offloading.data
+
+data class Classification(val label: String, val confidence: Double)

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/ImageAnalyzer.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/ImageAnalyzer.kt
@@ -1,0 +1,18 @@
+package ai.nnstreamer.ml.inference.offloading.data
+
+import ai.nnstreamer.ml.inference.offloading.domain.MobilenetClassifier
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+
+class ImageAnalyzer(
+    private val classifier: MobilenetClassifier,
+) : ImageAnalysis.Analyzer {
+    override fun analyze(imageProxy: ImageProxy) {
+        val rotationDegrees = imageProxy.imageInfo.rotationDegrees
+        val bitmap = imageProxy.toBitmap()
+
+        classifier.classify(bitmap, rotationDegrees)
+
+        imageProxy.close()
+    }
+}

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/domain/MobilenetClassifier.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/domain/MobilenetClassifier.kt
@@ -1,0 +1,152 @@
+package ai.nnstreamer.ml.inference.offloading.domain
+
+import ai.nnstreamer.ml.inference.offloading.MessageType
+import ai.nnstreamer.ml.inference.offloading.data.Classification
+import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import org.nnsuite.nnstreamer.NNStreamer
+import org.nnsuite.nnstreamer.Pipeline
+import org.nnsuite.nnstreamer.TensorsData
+import org.nnsuite.nnstreamer.TensorsInfo
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import kotlin.experimental.and
+
+object MobileNetPipeline {
+    private const val TAG = "MobileNetPipeline"
+    private const val SRC_PAD = "srcx"
+    private const val SINK_PAD = "sinkx"
+    var onResultsCb: ((List<Classification>) -> Unit)? = null
+    var pipeline: Pipeline? = null
+    var labels = arrayOf<String>()
+
+    private fun stateChangeCallback(): Pipeline.StateChangeCallback =
+        Pipeline.StateChangeCallback { state ->
+            when (state) {
+                Pipeline.State.UNKNOWN -> {
+                    Log.d(TAG, state.toString())
+                }
+
+                Pipeline.State.NULL -> {
+                    Log.d(TAG, state.toString())
+                }
+
+                Pipeline.State.READY -> {
+                    Log.d(TAG, state.toString())
+                }
+
+                Pipeline.State.PAUSED -> {
+                    Log.d(TAG, state.toString())
+                }
+
+                Pipeline.State.PLAYING -> {
+                    Log.d(TAG, state.toString())
+                }
+
+                null -> {
+                    Log.e(TAG, "null")
+                }
+            }
+        }
+
+
+    fun incomingNewDataCb(): Pipeline.NewDataCallback = Pipeline.NewDataCallback { data ->
+        var label = ""
+        var maxScore = 0
+        // todo: Use a list/array compression
+        data.getTensorData(0).run {
+            var index = -1
+
+            for (i in 0..1000) {
+                val score: Int = (this.get(i).and(0xFF.toByte())).toInt()
+
+                if (score > maxScore) {
+                    maxScore = score
+                    index = i
+                }
+            }
+
+            label = labels[index]
+        }
+
+        onResultsCb?.run {
+            val classifications = mutableListOf<Classification>()
+
+            classifications.add(Classification(label, maxScore.toDouble()))
+            this(classifications)
+        }
+    }
+
+    fun create(filter: String) {
+        val desc =
+            "appsrc caps=image/jpeg name=$SRC_PAD ! jpegdec ! videoconvert ! videoscale ! tensor_converter ! $filter ! tensor_sink name=$SINK_PAD"
+        pipeline = Pipeline(desc, stateChangeCallback()).apply {
+            registerSinkCallback(
+                SINK_PAD,
+                incomingNewDataCb()
+            )
+            start()
+        }
+    }
+
+    var state = pipeline?.getState()
+    val pushInputData: (inData: TensorsData) -> Unit = { inData ->
+        pipeline?.inputData(SRC_PAD, inData)
+    }
+}
+
+class MobilenetClassifier(
+    messenger: Messenger?,
+    onResults: (List<Classification>) -> Unit
+) : ObjectClassifier {
+    init {
+        MobileNetPipeline.onResultsCb = onResults
+        if (MobileNetPipeline.pipeline == null) {
+            val msg = Message.obtain(null, MessageType.REQ_OBJ_CLASSIFICATION_FILTER.value)
+            val callback = Handler.Callback {
+                CoroutineScope(Dispatchers.Main.immediate).launch {
+                    supervisorScope {
+                        val filter = async {
+                            it.data.getString("filter") ?: ""
+                        }.await()
+                        MobileNetPipeline.create(filter)
+                        val labels = async { it.data.getStringArray("labels") }.await()
+                        if (labels != null) {
+                            MobileNetPipeline.labels = labels
+                        }
+                    } // supervisorScope
+                } // CoroutineScope
+                true
+            } // Handler.Callback
+            msg.replyTo = Messenger(Handler(Looper.getMainLooper(), callback))
+            messenger?.send(msg)
+        }
+    }
+
+    override fun classify(bitmap: Bitmap, rotation: Int): List<Classification> {
+        val outputStream = ByteArrayOutputStream()
+
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+        val info = TensorsInfo().apply {
+            addTensorInfo(NNStreamer.TensorType.UINT8, intArrayOf(outputStream.size(), 1))
+        }
+        val data = TensorsData.allocate(info)
+        val byteBuffer = ByteBuffer.wrap(outputStream.toByteArray())
+        val buffer = TensorsData.allocateByteBuffer(info.getTensorSize(0))
+
+        buffer.put(byteBuffer)
+        data.setTensorData(0, buffer)
+        MobileNetPipeline.pushInputData(data)
+
+        return listOf<Classification>()
+    }
+}

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/domain/ObjectClassifier.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/domain/ObjectClassifier.kt
@@ -1,0 +1,8 @@
+package ai.nnstreamer.ml.inference.offloading.domain
+
+import ai.nnstreamer.ml.inference.offloading.data.Classification
+import android.graphics.Bitmap
+
+interface ObjectClassifier {
+    fun classify(bitmap: Bitmap, rotation: Int): List<Classification>
+}

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/ui/MainViewModel.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/ui/MainViewModel.kt
@@ -58,7 +58,7 @@ class MainViewModel @Inject constructor(private val offloadingServiceRepositoryI
                     val newState = OffloadingServiceUiState(it.serviceId, it.state, it.port)
                     newList.add(newState)
                 }
-                _services.value = newList.toList()
+                _services.emit(newList)
             }
         }
     }


### PR DESCRIPTION
This patch adds a draft of the vision example (i.e., an object classification scenario using MobileNet_v1) that exploits the MLAgent
Service.

Signed-off-by: Wook Song <wook16.song@samsung.com>
