### PR TITLE
Data/Model: Support invoke-dynamic option

### DIFF
--- a/documentation/example_conf/llama2c.conf
+++ b/documentation/example_conf/llama2c.conf
@@ -10,7 +10,7 @@
         ],
         "output_info" : [
           {
-            "type" : "uint8"
+            "format" : "flexible"
           }
         ]
     }

--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Model.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/Model.kt
@@ -134,7 +134,7 @@ data class Model(
     }
 
     private fun getType(list: List<String>): String {
-        val filtered = list.filterNot{ it.isEmpty() or it.isBlank() }
+        val filtered = list.filterNot { it.isEmpty() or it.isBlank() }
         return if (filtered.isEmpty()) {
             ""
         } else {
@@ -177,9 +177,11 @@ data class Model(
         val inDims = inputInfo["dimension"]?.let { getDimension(it) } ?: ""
         val outDims = outputInfo["dimension"]?.let { getDimension(it) } ?: ""
 
+        val invokeDynamic = if (outFormat != "static") "TRUE" else "FALSE"
+
         val filter =
             "other/tensors,format=${inFormat}${inTensors}${inDims}${inTypes},framerate=0/1 ! " +
-                    "tensor_filter framework=${framework} model=${modelPaths} ! " +
+                    "tensor_filter framework=${framework} model=${modelPaths} invoke-dynamic=$invokeDynamic ! " +
                     "other/tensors,format=${outFormat}${outTensors}${outDims}${outTypes},framerate=0/1"
 
         return filter


### PR DESCRIPTION
Data/Model: Support invoke-dynamic option
This patch supports invoke-dynamic option at tensor_filter.
If output tensor format is flexible, invoke-dynamic has to be set TRUE.

Conf: Change llama2 output to flexbile
This patch changes llama2 configuration file.
Output flexbile is now supported, so changed it from uint8 static to flexible.