### PR TITLE
App/Vision: Update the ImageAnalyzer class to support frame-skipping

### DIFF
--- a/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/ImageAnalyzer.kt
+++ b/ml_inference_offloading/src/main/java/ai/nnstreamer/ml/inference/offloading/data/ImageAnalyzer.kt
@@ -6,13 +6,20 @@ import androidx.camera.core.ImageProxy
 
 class ImageAnalyzer(
     private val classifier: MobilenetClassifier,
+    private val frameSkipRate: Int = 30,
+    private val shouldAnalyze: (ImageProxy, Int) -> Boolean = { _, frameCount -> frameCount % frameSkipRate == 0 }
 ) : ImageAnalysis.Analyzer {
+    private var frameSkipCounter = 0
+
     override fun analyze(imageProxy: ImageProxy) {
-        val rotationDegrees = imageProxy.imageInfo.rotationDegrees
-        val bitmap = imageProxy.toBitmap()
+        if (shouldAnalyze(imageProxy, frameSkipCounter)) {
+            val rotationDegrees = imageProxy.imageInfo.rotationDegrees
+            val bitmap = imageProxy.toBitmap()
 
-        classifier.classify(bitmap, rotationDegrees)
+            classifier.classify(bitmap, rotationDegrees)
+        }
 
+        frameSkipCounter = (frameSkipCounter + 1) % frameSkipRate
         imageProxy.close()
     }
 }


### PR DESCRIPTION
This patch updates the ImageAnalyzer class, which is an abstraction layer of the concrete image analysis implementation, to support condition-based frame-skipping.

Signed-off-by: Wook Song <wook16.song@samsung.com>
