### PR TITLE
Gradle/Android: Fix the warning related to unable to strip native libs

### DIFF
--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -21,6 +21,7 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
+        ndkVersion = "25.2.9519653"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
This patch fixes the following warning to reduce the APK's file size.

"Unable to strip the following libraries, packaging them as they are:
  libandroidx.graphics.path.so,
  libc++_shared.so,
  libdatastore_shared_counter.so,
  libgstreamer_android.so,
  libimage_processing_util_jni.so,
  libnnstreamer-native.so,
  libtensorflowlite.so,
  libtensorflowlite_gpu_delegate.so."

This size of `./ml_inference_offloading/build/outputs/apk/release/ml_inference_offloading-release-unsigned.apk ` comparisons

|   | Before | After |
|---|---|---|
| Size  |  1.1GiB | 289MiB   |