### PR TITLE
Gradle/Android: Fix the gradle task that cleans the entire project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,5 +20,6 @@ tasks {
     register("cleanAll") {
         dependsOn("nnstreamer-api:cleanAll")
         dependsOn("externals:cleanAll")
+        dependsOn("ml_inference_offloading:cleanAll")
     }
 }

--- a/ml_inference_offloading/build.gradle.kts
+++ b/ml_inference_offloading/build.gradle.kts
@@ -79,6 +79,10 @@ tasks {
             }
         }
     }
+
+    register("cleanAll", Delete::class) {
+        dependsOn("clean")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This patch resolves the bug in the 'cleanAll' gradle task, which now also cleans the omitted sub-project.

Signed-off-by: Wook Song <wook16.song@samsung.com>